### PR TITLE
Add device type API

### DIFF
--- a/src/qube_server/server.py
+++ b/src/qube_server/server.py
@@ -184,6 +184,11 @@ class QuBE_Server(DeviceServer):
             return False
         return True
 
+    @setting(20, "Device Type", returns=["s"])
+    def device_type(self, c):
+        dev = self.selectedDevice(c)
+        return dev.device_type.name
+
     @setting(100, "Shots", num_shots=["w"], returns=["w"])
     def number_of_shots(self, c, num_shots=None):
         """

--- a/src/qube_server/server.py
+++ b/src/qube_server/server.py
@@ -359,7 +359,6 @@ class QuBE_Server(DeviceServer):
 
         return dlist
 
-
     @setting(112, "DAQ Clear", returns=["b"])
     def daq_clear(self, c):
         raise NotImplementedError()

--- a/src/qube_server/server.py
+++ b/src/qube_server/server.py
@@ -421,7 +421,7 @@ class QuBE_Server(DeviceServer):
                 The number of available AWG channels.
         """
         dev = self.selectedDevice(c)
-        return dev.number_of_awgs
+        return len(dev.channels_of_port)
 
     @setting(200, "Upload Parameters", channels=["w", "*w"], returns=["b"])
     def upload_parameters(self, c, channels):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -278,12 +278,12 @@ def test_timeout(qube_server: QuBE_Server, context):
 def test_daq_channel(qube_server_with_fake_devices: QuBE_Server, fake_devices, context):
     server = qube_server_with_fake_devices
     dev1, dev2, _ = fake_devices
-    dev1.number_of_awgs = 4
-    dev2.number_of_awgs = 5
+    dev1.channels_of_port = {0, 1, 2}
+    dev2.channels_of_port = {0, 1}
     server.select_device(context, dev1.name)
-    assert server.daq_channels(context) == 4
+    assert server.daq_channels(context) == 3
     server.select_device(context, dev2.name)
-    assert server.daq_channels(context) == 5
+    assert server.daq_channels(context) == 2
 
 
 def test_upload_parameter(


### PR DESCRIPTION
Add API to retrieve the device type of a selected device.
As the device type cannot be identified from the device name in a new naming rule, an API to get the device type is required for the compatibility with measurement_tools.