### PR TITLE
Lab test with quelware 0.10

### DIFF
--- a/src/qube_server/constants.py
+++ b/src/qube_server/constants.py
@@ -60,14 +60,13 @@ class QSConstants:
     #   taps prior to decimation process.
     ACQ_FCOEF_BITS = 16  # - The number of vertical bits of the
     #   FIR filter coefficient.
-    ACQ_FCBIT_POW_HALF = 2**15  # - equivalent to 2^(ACQ_FCOEF_BITS-1).
+    ACQ_FCBIT_EXP_OFFSET = 15  # - ACQ_FCOEF_BITS-1.
     ACQ_MAX_WCOEF = 256  # - The maximally applicable complex
     #   window coefficients. It is equiva-
     #   lent to ACQ_MAXWINDOW * ADCDCM_
     #   SAMPLE_R.
     ACQ_WCOEF_BITS = 31  # - The number of vertical bits of the
     #   complex window coefficients.
-    ACQ_WCBIT_POW_HALF = 2**30  # - equivalent to 2^(ACQ_WCOEF_BITS-1)
     ACQ_MAXNUMCAPT = 8  # - Maximum iteration number of acquisi-
     #   tion window in a single sequence.
     #   DEBUG: There is no obvious reason to
@@ -97,7 +96,7 @@ class QSConstants:
     DAQ_INITSDLY = 1  # seconds; synchronization delay
     ACQ_INITMODE = "3"
     ACQ_INITWINDOW = [(0, 2048)]  # initial demodulation windows
-    ACQ_INITFIRCOEF = np.array([1] * 8).astype(
+    ACQ_INITFIRCOEF = np.array([1] * 16).astype(
         complex
     )  # initial complex FIR filter coeffs
     ACQ_INITWINDCOEF = np.array([]).astype(complex)  # initial complex window coeffs

--- a/src/qube_server/devices.py
+++ b/src/qube_server/devices.py
@@ -194,8 +194,9 @@ class QuBE_ControlPort(QuBE_DeviceBase):
 
         awg_param = AwgParam(num_wait_word=0, num_repeat=self.number_of_shots)
         waveform_name = f"{self.name}-{channel}"
+        iq = QSConstants.DAC_BITS_POW_HALF*waveform
         self.box_conn.box_unsafe.register_wavedata(
-            port=self.port_out, channel=channel, name=waveform_name, iq=waveform
+            port=self.port_out, channel=channel, name=waveform_name, iq=iq
         )
         awg_param.chunks.append(
             WaveChunk(

--- a/src/qube_server/devices.py
+++ b/src/qube_server/devices.py
@@ -414,7 +414,7 @@ class QuBE_ReadoutPort(QuBE_ControlPort):
             # in the readout window.
             # resp = self.configure_readout_summation(mux, param, summn)
             param.sum_enable = True
-            param.sum_range = (0, param.num_section)
+            param.sum_range = (0, (len(self._window_coefs[mux])//4)-1)
             param.window_enable = True
             param.window_coeff = self._window_coefs[mux]
 

--- a/src/qube_server/devices.py
+++ b/src/qube_server/devices.py
@@ -306,20 +306,10 @@ class QuBE_ReadoutPort(QuBE_ControlPort):
         self._acq_mode[mux] = mode
 
     def set_acquisition_fir_coefficient(self, muxch, coeffs):
-        def fircoef_DACify(coeffs):
-            return (np.real(coeffs) * QSConstants.ACQ_FCBIT_POW_HALF).astype(
-                int
-            ) + 1j * (np.imag(coeffs) * QSConstants.ACQ_FCBIT_POW_HALF).astype(int)
-
-        self._fir_coefs[muxch] = fircoef_DACify(coeffs)
+        self._fir_coefs[muxch] = coeffs
 
     def set_acquisition_window_coefficient(self, muxch, coeffs):
-        def window_DACify(coeffs):
-            return (np.real(coeffs) * QSConstants.ACQ_WCBIT_POW_HALF).astype(
-                int
-            ) + 1j * (np.imag(coeffs) * QSConstants.ACQ_WCBIT_POW_HALF).astype(int)
-
-        self._window_coefs[muxch] = window_DACify(coeffs)
+        self._window_coefs[muxch] = coeffs
 
     def upload_readout_parameters(self, muxch):
         """
@@ -408,9 +398,9 @@ class QuBE_ReadoutPort(QuBE_ControlPort):
 
         if decim:
             # [Decimation] 500MSa/s datapoints are reduced to 125 MSa/s (8ns interval)
-            param.realfirs_real_coeff = self._fir_coefs[mux].real
-            param.realfirs_imag_coeff = self._fir_coefs[mux].imag
-            param.realfirs_enable = True
+            param.complexfir_coeff = self._fir_coefs[mux]
+            param.complexfir_exponent_offset = QSConstants.ACQ_FCBIT_EXP_OFFSET
+            param.complexfir_enable = True
             param.decimation_enable = True
         if averg:
             # [Averaging] Averaging datapoints for all experiments.

--- a/src/qube_server/server.py
+++ b/src/qube_server/server.py
@@ -316,7 +316,7 @@ class QuBE_Server(DeviceServer):
             )
 
         # the first box is used as a tentative master
-        cur_timecounter = box_conns[0].get_latest_sysref_timecounter()
+        cur_timecounter = int(box_conns[0].box_unsafe.get_current_timecounter())
         latest_trigger_timecounter = max(
             bc.last_trigger_timecounter - bc.timecounter_offset for bc in box_conns
         )
@@ -450,7 +450,7 @@ class QuBE_Server(DeviceServer):
         """
         Register selected DAC AWG channels
 
-        The method [_register_awg_channels()] register the enabled AWG IDs tothe device context.
+        The method [_register_awg_channels()] register the enabled AWG IDs to the device context.
         This information is used in daq_start() and daq_trigger()
 
         Data structure:


### PR DESCRIPTION
# Changes
## FIR coeff
* Use complexfir_coeff instead of realfirs_real_coeff (QubeServer was originally using complexfir_coeff)
* Delete DACify, now done in e7awghal 
* complexfir_exponent_offset = 15, consistent with |v|<2.0 normalization of the old QubeServer

## Waveform coeff
* Delete DACify, now done in e7awghal 

## QSConstants
* Delete ACQ_FCBIT_POW_HALF, define ACQ_FCBIT_EXP_OFFSET instead
* Delete ACQ_WCBIT_POW_HALF
* Change the length of ACQ_INITFIRCOEF from 8 to 16 (probably the bug of original qube server)

## Summation of waveform
* Fix a bug of sum_range

## Trigger
* Change the trigger to use current counter instead of current sysref
