### PR TITLE
QuEL-1 compatibility, Add port type information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 lint:
 	uv run ruff check .
 
+fix-lint-errors:
+	uv run ruff check --fix
+
 format:
 	uv run ruff check --select I --fix
 	uv run ruff format

--- a/src/qube_server/box_connection.py
+++ b/src/qube_server/box_connection.py
@@ -123,6 +123,7 @@ class BoxConnection:
             channels=channels, timecounter=timecounter_raw
         )
 
+
 def acquire_all_locks(
     box_conns: Collection[BoxConnection],
     context_id: ContextId,

--- a/src/qube_server/box_connection.py
+++ b/src/qube_server/box_connection.py
@@ -111,6 +111,17 @@ class BoxConnection:
             runits=runits, channels=channels, timecounter=timecounter_raw
         )
 
+    def start_wavegen(
+        self,
+        context_id: ContextId,
+        channels: Collection[tuple[Quel1PortType, int]],
+        timecounter: int,
+    ) -> AbstractStartAwgunitsTask:
+        self._last_trigger_timecounter = timecounter
+        timecounter_raw = timecounter + self._timecounter_offset
+        return self.get_box(context_id).start_wavegen(
+            channels=channels, timecounter=timecounter_raw
+        )
 
 def acquire_all_locks(
     box_conns: Collection[BoxConnection],

--- a/src/qube_server/devices.py
+++ b/src/qube_server/devices.py
@@ -399,7 +399,7 @@ class QuBE_ReadoutPort(QuBE_ControlPort):
 
         if decim:
             # [Decimation] 500MSa/s datapoints are reduced to 125 MSa/s (8ns interval)
-            param.complexfir_coeff = self._fir_coefs[mux]
+            param.complexfir_coeff = np.array(self._fir_coefs[mux])[::-1] # reverse the order for covolution (e7agwhal will implement this in future)
             param.complexfir_exponent_offset = QSConstants.ACQ_FCBIT_EXP_OFFSET
             param.complexfir_enable = True
             param.decimation_enable = True

--- a/src/qube_server/devices.py
+++ b/src/qube_server/devices.py
@@ -7,18 +7,37 @@ from typing import NamedTuple, Optional, TypedDict, cast
 
 import numpy as np
 from labrad.devices import DeviceWrapper
-from quel_ic_config import AwgParam, CapParam, CapSection, Quel1PortType, WaveChunk
+from quel_ic_config import AwgParam, CapParam, CapSection, Quel1PortType, WaveChunk, Quel1BoxType
 
 from .box_connection import BoxConnection
 from .constants import QSConstants, QSMessage
 
 
 class DeviceType(Enum):
-    ctrl = auto()
-    readout = auto()
-    fogi = auto()
-    pump = auto()
+    ctrl = "control"
+    readout = "readout"
+    pump = "pump"
+    readin = "readin"  # paired with readout, just used for creating device_name
 
+ADC_DAC_PORT_PAIR_DICT: dict[Quel1BoxType, dict[Quel1PortType, Quel1PortType]] = {
+    Quel1BoxType.QuEL1SE_RIKEN8: {
+        0: 1
+    }
+}
+
+DAC_PORT_TYPE_DICT: dict[Quel1BoxType, dict[Quel1PortType, DeviceType]] = {
+    Quel1BoxType.QuEL1SE_RIKEN8: {
+        0: DeviceType.readin,
+        1: DeviceType.readout,
+        (1, 1): DeviceType.ctrl,
+        2: DeviceType.pump,
+        3: DeviceType.ctrl,
+        6: DeviceType.ctrl,
+        7: DeviceType.ctrl,
+        8: DeviceType.ctrl,
+        9: DeviceType.ctrl
+    }
+}
 
 class DeviceConnectionInfo(NamedTuple):
     """A set of Arguments for DeviceWrapper.connect"""
@@ -49,19 +68,28 @@ def create_device_connection_infos_from_box_connection(
         elif isinstance(box_port, tuple) and len(box_port) == 2:
             return f"{port_prefix}{box_port[0]:02d}-{box_port[1]:02d}"
 
-    for input_port in box_conn._box.get_read_input_ports():
-        paired_output_ports = box_conn._box.get_loopbacks_of_port(input_port)
-        if len(paired_output_ports) < 1:
-            continue
-        paired_output_port = paired_output_ports.pop()
+    port_type_dict = DAC_PORT_TYPE_DICT[Quel1BoxType.fromstr(box_conn.box_unsafe.boxtype)]
+    port_pair_dict = ADC_DAC_PORT_PAIR_DICT[Quel1BoxType.fromstr(box_conn.box_unsafe.boxtype)]
 
-        name = f"{box_conn.box_name}-{_create_boxport_str(input_port, port_prefix='in')}-{_create_boxport_str(paired_output_port, port_prefix='out')}"
+    all_output_ports = box_conn.box_unsafe.get_output_ports()
+ 
+    for input_port in box_conn._box.get_read_input_ports():
+        if input_port in port_pair_dict:
+            paired_output_port = port_pair_dict[input_port]
+        else:
+            continue
+ 
+        input_port_type = port_type_dict[input_port]
+        output_port_type = port_type_dict[paired_output_port]
+        all_output_ports.remove(paired_output_port)
+
+        name = f"{box_conn.box_name}-{_create_boxport_str(input_port, port_prefix=f'{input_port_type.value}_')}-{_create_boxport_str(paired_output_port, port_prefix=f'{output_port_type.value}_')}"
         dev_conn_infos.append(
             DeviceConnectionInfo(
                 name=name,
                 args=DeviceConnectionInfoArgs(
                     box_conn=box_conn,
-                    device_type=DeviceType.readout,
+                    device_type=output_port_type,
                     port_in=input_port,
                     port_out=paired_output_port,
                 ),
@@ -69,16 +97,17 @@ def create_device_connection_infos_from_box_connection(
             )
         )
 
-    for output_port in box_conn._box.get_output_ports():
+    for output_port in all_output_ports:
+        output_port_type = port_type_dict[output_port]
         name = (
-            f"{box_conn.box_name}-{_create_boxport_str(output_port, port_prefix='out')}"
+            f"{box_conn.box_name}-{_create_boxport_str(output_port, port_prefix=f'{output_port_type.value}_')}"
         )
         dev_conn_infos.append(
             DeviceConnectionInfo(
                 name=name,
                 args=DeviceConnectionInfoArgs(
                     box_conn=box_conn,
-                    device_type=DeviceType.ctrl,
+                    device_type=output_port_type,
                     port_in=None,
                     port_out=output_port,
                 ),
@@ -465,9 +494,5 @@ class QuBE_ReadoutPort(QuBE_ControlPort):
         if resp:
             resp = 1.0 > np.max(np.abs(coeffs))
         return resp
-
-
-class QuBE_FogiPort(QuBE_ControlPort): ...
-
 
 class QuBE_PumpPort(QuBE_ControlPort): ...

--- a/src/qube_server/devices.py
+++ b/src/qube_server/devices.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 import copy
 from abc import abstractmethod
-from enum import Enum, auto
+from enum import Enum
 from typing import NamedTuple, Optional, TypedDict, cast
 
 import numpy as np
 from labrad.devices import DeviceWrapper
-from quel_ic_config import AwgParam, CapParam, CapSection, Quel1PortType, WaveChunk, Quel1BoxType
+from quel_ic_config import (
+    AwgParam,
+    CapParam,
+    CapSection,
+    Quel1BoxType,
+    Quel1PortType,
+    WaveChunk,
+)
 
 from .box_connection import BoxConnection
 from .constants import QSConstants, QSMessage
@@ -19,16 +26,11 @@ class DeviceType(Enum):
     pump = "pump"
     readin = "readin"  # paired with readout, just used for creating device_name
 
+
 ADC_DAC_PORT_PAIR_DICT: dict[Quel1BoxType, dict[Quel1PortType, Quel1PortType]] = {
-    Quel1BoxType.QuEL1SE_RIKEN8: {
-        0: 1
-    },
-    Quel1BoxType.QuEL1_TypeA: {
-        0: 1,
-        7: 8
-    },
-    Quel1BoxType.QuEL1_TypeB: {
-    }
+    Quel1BoxType.QuEL1SE_RIKEN8: {0: 1},
+    Quel1BoxType.QuEL1_TypeA: {0: 1, 7: 8},
+    Quel1BoxType.QuEL1_TypeB: {},
 }
 
 DAC_PORT_TYPE_DICT: dict[Quel1BoxType, dict[Quel1PortType, DeviceType]] = {
@@ -41,7 +43,7 @@ DAC_PORT_TYPE_DICT: dict[Quel1BoxType, dict[Quel1PortType, DeviceType]] = {
         6: DeviceType.ctrl,
         7: DeviceType.ctrl,
         8: DeviceType.ctrl,
-        9: DeviceType.ctrl
+        9: DeviceType.ctrl,
     },
     Quel1BoxType.QuEL1_TypeA: {
         0: DeviceType.readin,
@@ -53,7 +55,7 @@ DAC_PORT_TYPE_DICT: dict[Quel1BoxType, dict[Quel1PortType, DeviceType]] = {
         8: DeviceType.readout,
         9: DeviceType.ctrl,
         10: DeviceType.pump,
-        11: DeviceType.ctrl
+        11: DeviceType.ctrl,
     },
     Quel1BoxType.QuEL1_TypeB: {
         1: DeviceType.ctrl,
@@ -63,9 +65,10 @@ DAC_PORT_TYPE_DICT: dict[Quel1BoxType, dict[Quel1PortType, DeviceType]] = {
         8: DeviceType.ctrl,
         9: DeviceType.ctrl,
         10: DeviceType.ctrl,
-        11: DeviceType.ctrl
-    }
+        11: DeviceType.ctrl,
+    },
 }
+
 
 class DeviceConnectionInfo(NamedTuple):
     """A set of Arguments for DeviceWrapper.connect"""
@@ -96,17 +99,21 @@ def create_device_connection_infos_from_box_connection(
         elif isinstance(box_port, tuple) and len(box_port) == 2:
             return f"{port_prefix}{box_port[0]:02d}-{box_port[1]:02d}"
 
-    port_type_dict = DAC_PORT_TYPE_DICT[Quel1BoxType.fromstr(box_conn.box_unsafe.boxtype)]
-    port_pair_dict = ADC_DAC_PORT_PAIR_DICT[Quel1BoxType.fromstr(box_conn.box_unsafe.boxtype)]
+    port_type_dict = DAC_PORT_TYPE_DICT[
+        Quel1BoxType.fromstr(box_conn.box_unsafe.boxtype)
+    ]
+    port_pair_dict = ADC_DAC_PORT_PAIR_DICT[
+        Quel1BoxType.fromstr(box_conn.box_unsafe.boxtype)
+    ]
 
     all_output_ports = box_conn.box_unsafe.get_output_ports()
- 
+
     for input_port in box_conn._box.get_read_input_ports():
         if input_port in port_pair_dict:
             paired_output_port = port_pair_dict[input_port]
         else:
             continue
- 
+
         input_port_type = port_type_dict[input_port]
         output_port_type = port_type_dict[paired_output_port]
         all_output_ports.remove(paired_output_port)
@@ -127,9 +134,7 @@ def create_device_connection_infos_from_box_connection(
 
     for output_port in all_output_ports:
         output_port_type = port_type_dict[output_port]
-        name = (
-            f"{box_conn.box_name}-{_create_boxport_str(output_port, port_prefix=f'{output_port_type.value}_')}"
-        )
+        name = f"{box_conn.box_name}-{_create_boxport_str(output_port, port_prefix=f'{output_port_type.value}_')}"
         dev_conn_infos.append(
             DeviceConnectionInfo(
                 name=name,
@@ -456,7 +461,11 @@ class QuBE_ReadoutPort(QuBE_ControlPort):
 
         if decim:
             # [Decimation] 500MSa/s datapoints are reduced to 125 MSa/s (8ns interval)
-            param.complexfir_coeff = np.array(self._fir_coefs[mux])[::-1] # reverse the order for covolution (e7agwhal will implement this in future)
+            param.complexfir_coeff = np.array(
+                self._fir_coefs[mux]
+            )[
+                ::-1
+            ]  # reverse the order for covolution (e7agwhal will implement this in future)
             param.complexfir_exponent_offset = QSConstants.ACQ_FCBIT_EXP_OFFSET
             param.complexfir_enable = True
             param.decimation_enable = True
@@ -522,5 +531,6 @@ class QuBE_ReadoutPort(QuBE_ControlPort):
         if resp:
             resp = 1.0 > np.max(np.abs(coeffs))
         return resp
+
 
 class QuBE_PumpPort(QuBE_ControlPort): ...

--- a/src/qube_server/devices.py
+++ b/src/qube_server/devices.py
@@ -22,6 +22,12 @@ class DeviceType(Enum):
 ADC_DAC_PORT_PAIR_DICT: dict[Quel1BoxType, dict[Quel1PortType, Quel1PortType]] = {
     Quel1BoxType.QuEL1SE_RIKEN8: {
         0: 1
+    },
+    Quel1BoxType.QuEL1_TypeA: {
+        0: 1,
+        7: 8
+    },
+    Quel1BoxType.QuEL1_TypeB: {
     }
 }
 
@@ -36,6 +42,28 @@ DAC_PORT_TYPE_DICT: dict[Quel1BoxType, dict[Quel1PortType, DeviceType]] = {
         7: DeviceType.ctrl,
         8: DeviceType.ctrl,
         9: DeviceType.ctrl
+    },
+    Quel1BoxType.QuEL1_TypeA: {
+        0: DeviceType.readin,
+        1: DeviceType.readout,
+        2: DeviceType.ctrl,
+        3: DeviceType.pump,
+        4: DeviceType.ctrl,
+        7: DeviceType.readin,
+        8: DeviceType.readout,
+        9: DeviceType.ctrl,
+        10: DeviceType.pump,
+        11: DeviceType.ctrl
+    },
+    Quel1BoxType.QuEL1_TypeB: {
+        1: DeviceType.ctrl,
+        2: DeviceType.ctrl,
+        3: DeviceType.ctrl,
+        4: DeviceType.ctrl,
+        8: DeviceType.ctrl,
+        9: DeviceType.ctrl,
+        10: DeviceType.ctrl,
+        11: DeviceType.ctrl
     }
 }
 

--- a/src/qube_server/server.py
+++ b/src/qube_server/server.py
@@ -30,7 +30,6 @@ from .devices import (
     DeviceType,
     QuBE_ControlPort,
     QuBE_DeviceBase,
-    QuBE_FogiPort,
     QuBE_PumpPort,
     QuBE_ReadoutPort,
     create_device_connection_infos_from_box_connection,
@@ -126,8 +125,6 @@ class QuBE_Server(DeviceServer):
             return QuBE_ControlPort
         elif args.device_type is DeviceType.readout:
             return QuBE_ReadoutPort
-        elif args.device_type is DeviceType.fogi:
-            return QuBE_FogiPort
         elif args.device_type is DeviceType.pump:
             return QuBE_PumpPort
         else:
@@ -187,7 +184,7 @@ class QuBE_Server(DeviceServer):
     @setting(20, "Device Type", returns=["s"])
     def device_type(self, c):
         dev = self.selectedDevice(c)
-        return dev.device_type.name
+        return dev.device_type.value
 
     @setting(100, "Shots", num_shots=["w"], returns=["w"])
     def number_of_shots(self, c, num_shots=None):

--- a/src/qube_server/server.py
+++ b/src/qube_server/server.py
@@ -322,15 +322,22 @@ class QuBE_Server(DeviceServer):
         ) & 0xFFFFFFFFFFFFFFF0
 
         for bc in box_conns:
-            cap_task, awg_task = bc.start_capture_by_awg_trigger(
-                c.ID,
-                runits=c[QSConstants.ACQ_CNXT_TAG][bc.box_name],
-                channels=c[QSConstants.DAC_CNXT_TAG][bc.box_name],
-                timecounter=timecounter,
-            )
-            print(bc.box_name, "kick at ", timecounter)
-            c[QSConstants.CAP_TASK_TAG][bc.box_name] = cap_task
+            if bc.box_name in c[QSConstants.ACQ_CNXT_TAG]:
+                cap_task, awg_task = bc.start_capture_by_awg_trigger(
+                    c.ID,
+                    runits=c[QSConstants.ACQ_CNXT_TAG][bc.box_name],
+                    channels=c[QSConstants.DAC_CNXT_TAG][bc.box_name],
+                    timecounter=timecounter,
+                )
+                c[QSConstants.CAP_TASK_TAG][bc.box_name] = cap_task
+            else:
+                awg_task = bc.start_wavegen(
+                    c.ID,
+                    channels=c[QSConstants.DAC_CNXT_TAG][bc.box_name],
+                    timecounter=timecounter,
+                )
             c[QSConstants.AWG_TASK_TAG][bc.box_name] = awg_task
+            print(bc.box_name, "kick at ", timecounter)
         release_all_locks(box_conns, c.ID)
         return True
 


### PR DESCRIPTION
# Changes
## CFIR filter
* Temporal fix of cfir coefficients: The order is reversed in the QubeServer. This should be reverted after e7awghal implement it.
## Type B compatibility
* Add `start_wavegen` method to run QuEL-1 type B without CaputerUnit.
## Device type identification
When the server generate device instances, we need to identify the ADC-DAC paring and DeviceType of ports. But the DeviceType is defined by users to decide the usage of ports. There is no build-in method to distinguish, for example, control ports and pump ports.
That is why, I added so far hardcoded mapping of
* ADC, DAC paring 
* DeviceType of ports