### PR TITLE
API to reconnect/relinkup box

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+QS_TEST_LINKS_JSON_PATH=/path/to/links.json
+QS_TEST_SKEW_JSON_PATH=/path/to/skew.json
+QS_TEST_PLOT=True
+QS_SKIP_TESTS_WITH_DEVICES=False

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Install build dependencies
-        run: |
-          : # sudo apt-get update
-          sudo apt-get install libcairo2-dev pkg-config python3-dev libgirepository-2.0-dev
-
       - name: Install the project
         run: uv sync --locked --dev
 

--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,4 @@ notebooks/
 
 qubesrv/config/
 
-.prebuilt
+artifacts/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ uv run qube_server
 
 ## For Developers
 
+To configure your development environment, create a `.env` file.
+An example, `.env.example`, is included in the project.
+As the first step, run `cp .env.example .env` and then modify the new `.env` file.
+
 To run linter and formatter, execute `make` command as following:
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "e7awghal>=0.1.5",
     "pydantic>=2.4.2",
     "pylabrad>=0.98.2",
+    "pytest-twisted>=1.14.3",
+    "python-dotenv>=1.1.1",
     "quel_ic_config>=0.10.4",
 ]
 

--- a/src/qube_server/box_connection.py
+++ b/src/qube_server/box_connection.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import sys
 import time
+import warnings
 from collections.abc import Collection
-from typing import Any, Final, NamedTuple, Optional
+from contextlib import contextmanager
+from typing import Any, Callable, Final, NamedTuple, Optional
 
 from quel_ic_config import (
     AbstractStartAwgunitsTask,
@@ -13,6 +16,7 @@ from quel_ic_config import (
 from typing_extensions import TypeAlias
 
 ContextId: TypeAlias = Any
+BoxFactory: TypeAlias = Callable[[], Quel1Box]
 
 
 class Lock(NamedTuple):
@@ -25,12 +29,18 @@ TIMEOUT_DURATION_DEFAULT: Final[float] = 5
 
 
 class BoxConnection:
-    def __init__(self, box_name: str, box: Quel1Box, timecounter_offset: int):
+    def __init__(self, box_name: str, box_factory: BoxFactory, timecounter_offset: int):
+        """
+        Adapter for the Quel1Box.
+        """
         self.box_name = box_name
-        self._box = box
-        self._resource_id_to_info = {}
-        self._lock: Optional[Lock] = None
+        self._box_factory = box_factory
+        self.__box: Optional[Quel1Box] = None
+        self._dumped_data: Optional[Any] = None
 
+        self.connect()
+
+        self._lock: Optional[Lock] = None
         self._timecounter_offset: int = timecounter_offset
         self._last_trigger_timecounter: int = 0
 
@@ -50,53 +60,61 @@ class BoxConnection:
     def last_trigger_timecounter(self, val):
         self._last_trigger_timecounter = val
 
-    def acquire_lock(self, context_id: ContextId, timeout_duration: float) -> bool:
-        self._check_and_release_timeout_locks()
+    def acquire_lock(
+        self, context_id: ContextId, timeout_duration: float = TIMEOUT_DURATION_DEFAULT
+    ) -> bool:
+        self._check_and_release_timed_out_lock()
         if self._lock is not None:
             if self._lock.context_id != context_id:
                 return False
         self._lock = Lock(
             context_id=context_id,
             acquire_time=time.time(),
-            timeout_duration=timeout_duration
-            if timeout_duration
-            else TIMEOUT_DURATION_DEFAULT,
+            timeout_duration=timeout_duration,
         )
         return True
 
     def release_lock(self, context_id: ContextId):
-        self._check_and_release_timeout_locks()
+        self._check_and_release_timed_out_lock()
         if self._lock is not None:
             if self._lock.context_id == context_id:
                 self._lock = None
 
-    def _check_and_release_timeout_locks(self):
+    def _check_and_release_timed_out_lock(self):
         if self._lock:
             if time.time() - self._lock.acquire_time > self._lock.timeout_duration:
                 self._lock = None
 
-    def _is_accessable_from_context(self, context_id: ContextId):
-        if self._lock is None or self._lock.context_id == context_id:
+    def _is_accessable_from_context(self, context_id: Optional[ContextId]):
+        self._check_and_release_timed_out_lock()
+        if self._lock is not None and self._lock.context_id == context_id:
             return True
         return False
 
-    def get_box(self, context_id: ContextId) -> Quel1Box:
+    def get_box(self, context_id: Optional[ContextId]) -> Quel1Box:
         if not self._is_accessable_from_context(context_id):
-            raise RuntimeError(f"Box '{self.box_name}' is locked from another context.")
-        return self._box
+            raise RuntimeError(
+                f"The context doesn't have the lock for Box '{self.box_name}'."
+            )
+        return self.box_unsafe
 
     @property
     def box_unsafe(self) -> Quel1Box:
         """
         Returns the Quel1Box instance without any lock checks.
         """
-        return self._box
+        if self.__box is None:
+            raise RuntimeError("No reference to Quel1Box.")
+        return self.__box
 
     def get_current_timecounter(self) -> int:
-        return int(self._box.get_current_timecounter()) - self._timecounter_offset
+        return int(self.box_unsafe.get_current_timecounter()) - self._timecounter_offset
 
     def get_latest_sysref_timecounter(self) -> int:
-        return int(self._box.get_latest_sysref_timecounter()) - self._timecounter_offset
+        return (
+            int(self.box_unsafe.get_latest_sysref_timecounter())
+            - self._timecounter_offset
+        )
 
     def start_capture_by_awg_trigger(
         self,
@@ -122,6 +140,34 @@ class BoxConnection:
         return self.get_box(context_id).start_wavegen(
             channels=channels, timecounter=timecounter_raw
         )
+
+    def disconnect(self, context_id: ContextId):
+        self._dumped_data = self.get_box(context_id).dump_box()
+        if (count := sys.getrefcount(self.__box)) > 1:
+            warnings.warn(
+                f"Reference to Quel1Box object seems to be leaked (count: {count}). Disconnection may be failed."
+            )
+        del self.__box
+
+    def connect(self, linkup: bool = False):
+        try:
+            if self.__box is not None:
+                raise ValueError("Box is already connected.")
+        except AttributeError:
+            pass
+        self.__box = self._box_factory()
+        if linkup:
+            self.__box.relinkup()
+        self.__box.reconnect()
+        if self._dumped_data is not None:
+            self.__box.config_box(self._dumped_data)
+            self._dumped_data = None
+
+    def purge(self):
+        """
+        Only for tests and debuggings.
+        """
+        del self.__box
 
 
 def acquire_all_locks(
@@ -150,7 +196,6 @@ def acquire_all_locks(
                 release_all_locks(acquired_box_conns, context_id)
                 return False
             acquired_box_conns.append(box_conn)
-        print(f"All locks acquired by [{context_id}].")
         return True
     except Exception:
         release_all_locks(acquired_box_conns, context_id)
@@ -168,3 +213,17 @@ def release_all_locks(
     """
     for box_conn in box_conns:
         box_conn.release_lock(context_id)
+
+
+@contextmanager
+def locked_boxes(
+    box_conns: Collection[BoxConnection],
+    context_id: ContextId,
+    timeout_duration: float = TIMEOUT_DURATION_DEFAULT,
+):
+    if not acquire_all_locks(box_conns, context_id, timeout_duration):
+        raise RuntimeError(
+            "Failed to atomically acquire locks because they are held by another context."
+        )
+    yield box_conns
+    release_all_locks(box_conns, context_id)

--- a/src/qube_server/devices.py
+++ b/src/qube_server/devices.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from abc import abstractmethod
-from enum import Enum
+from enum import Enum, auto
 from typing import NamedTuple, Optional, TypedDict, cast
 
 import numpy as np
@@ -25,6 +25,12 @@ class DeviceType(Enum):
     readout = "readout"
     pump = "pump"
     readin = "readin"  # paired with readout, just used for creating device_name
+
+
+class RfSwitchState(Enum):
+    undefined = auto()
+    loop = auto()
+    open = auto()
 
 
 ADC_DAC_PORT_PAIR_DICT: dict[Quel1BoxType, dict[Quel1PortType, Quel1PortType]] = {
@@ -486,6 +492,25 @@ class QuBE_ReadoutPort(QuBE_ControlPort):
     def get_adc_coarse_frequency(self):
         dumped = self.box_conn.box_unsafe.dump_port(self.port_in)
         return dumped["cnco_freq"]
+
+    def get_rfswitch(self) -> RfSwitchState:
+        state_in = self.box_conn.box_unsafe.dump_rfswitch(self.port_in)
+        state_out = self.box_conn.box_unsafe.dump_rfswitch(self.port_out)
+        if (state_in, state_out) == ("loop", "block"):
+            return RfSwitchState.loop
+        elif (state_in, state_out) == ("open", "pass"):
+            return RfSwitchState.open
+        return RfSwitchState.undefined
+
+    def set_rfswitch(self, state: RfSwitchState):
+        if state is RfSwitchState.open:
+            in_switch_str, out_switch_str = "open", "pass"
+        elif state is RfSwitchState.loop:
+            in_switch_str, out_switch_str = "loop", "block"
+        else:
+            raise ValueError(f"Unavailable switch state: {state}")
+        self.box_conn.box_unsafe.config_rfswitch(self.port_in, rfswitch=in_switch_str)
+        self.box_conn.box_unsafe.config_rfswitch(self.port_out, rfswitch=out_switch_str)
 
     def static_check_adc_coarse_frequency(self, freq):
         resolution = QSConstants.ADC_CNCO_RESOL

--- a/src/qube_server/devices.py
+++ b/src/qube_server/devices.py
@@ -114,7 +114,7 @@ def create_device_connection_infos_from_box_connection(
 
     all_output_ports = box_conn.box_unsafe.get_output_ports()
 
-    for input_port in box_conn._box.get_read_input_ports():
+    for input_port in box_conn.box_unsafe.get_read_input_ports():
         if input_port in port_pair_dict:
             paired_output_port = port_pair_dict[input_port]
         else:
@@ -468,7 +468,6 @@ class QuBE_ReadoutPort(QuBE_ControlPort):
         if decim:
             # [Decimation] 500MSa/s datapoints are reduced to 125 MSa/s (8ns interval)
             param.complexfir_coeff = np.array(self._fir_coefs[mux])
-            param.complexfir_exponent_offset = QSConstants.ACQ_FCBIT_EXP_OFFSET
             param.complexfir_enable = True
             param.decimation_enable = True
         if averg:

--- a/src/qube_server/server.py
+++ b/src/qube_server/server.py
@@ -32,6 +32,7 @@ from .devices import (
     QuBE_DeviceBase,
     QuBE_PumpPort,
     QuBE_ReadoutPort,
+    RfSwitchState,
     create_device_connection_infos_from_box_connection,
 )
 from .model import PossibleLinks, Skews
@@ -1087,6 +1088,29 @@ class QuBE_Server(DeviceServer):
         else:
             dev.set_mix_sideband(sideband)
         return sideband
+
+    @setting(505, "Internal loopback", enabled=["b"], returns=["b"])
+    def internal_loopback(self, c, enabled=None):
+        """
+        Enable loopback by controlling the rfswitches at the input and output ports.
+
+        Args:
+            enabled : b (bool)
+                If True, the internal loopback is enabled and no output.
+        Returns:
+            enabled : b (bool)
+                Current state of the switch.
+        """
+        dev = self.selectedDevice(c)
+
+        if dev.device_type is not DeviceType.readout:
+            ValueError(f"Loopback is not available for the device {dev.name}.")
+
+        if enabled is True:
+            dev.set_rfswitch(RfSwitchState.loop)
+        elif enabled is False:
+            dev.set_rfswitch(RfSwitchState.open)
+        return dev.get_rfswitch()
 
 
 def _convert_to_builtin_type(np_array, ensure_list=False):

--- a/src/qube_server/server.py
+++ b/src/qube_server/server.py
@@ -7,7 +7,8 @@ from typing import Any, Final, Optional, cast
 
 import numpy as np
 from labrad import types as T
-from labrad.devices import DeviceServer
+from labrad.devices import DeviceLockedError, DeviceServer, DeviceWrapper
+from labrad.errors import DeviceNotSelectedError
 from labrad.server import setting
 from labrad.units import Value
 from quel_ic_config import (
@@ -22,7 +23,7 @@ from typing_extensions import TypeAlias
 
 from qube_server.utils import is_reachable
 
-from .box_connection import BoxConnection, acquire_all_locks, release_all_locks
+from .box_connection import BoxConnection, locked_boxes
 from .constants import QSConstants, QSMessage
 from .devices import (
     DeviceConnectionInfo,
@@ -148,14 +149,17 @@ class QuBE_Server(DeviceServer):
                     )
 
                 print(QSMessage.CNCTABLE_QUBEUNIT.format(box_link.name))
-                box = Quel1Box.create(
-                    ipaddr_wss=box_link.ipaddr_wss,
-                    boxtype=Quel1BoxType.fromstr(box_link.boxtype),
-                )
-                box.reconnect()
+
+                def _box_factory():
+                    box = Quel1Box.create(
+                        ipaddr_wss=box_link.ipaddr_wss,
+                        boxtype=Quel1BoxType.fromstr(box_link.boxtype),
+                    )
+                    return box
+
                 box_conn = BoxConnection(
                     box_name=box_link.name,
-                    box=box,
+                    box_factory=_box_factory,
                     timecounter_offset=box_name_to_timecounter_offset[box_link.name],
                 )
                 self._name_to_box_conn[box_link.name] = box_conn
@@ -306,40 +310,34 @@ class QuBE_Server(DeviceServer):
 
         chassis_list = c[QSConstants.DAC_CNXT_TAG].keys()
         box_conns = [self._name_to_box_conn[box_name] for box_name in chassis_list]
-        if not acquire_all_locks(
-            box_conns, c.ID, timeout_duration=BOXLOCK_TIMEOUT_DURATION
-        ):
-            raise RuntimeError(
-                "Failed to atomically acquire locks because they are held by another context."
+
+        with locked_boxes(box_conns, c.ID, timeout_duration=BOXLOCK_TIMEOUT_DURATION):
+            # the first box is used as a tentative master
+            cur_timecounter = int(box_conns[0].get_current_timecounter())
+            latest_trigger_timecounter = max(
+                bc.last_trigger_timecounter for bc in box_conns
             )
+            timecounter = (
+                max(latest_trigger_timecounter, cur_timecounter) + delay
+            ) & 0xFFFFFFFFFFFFFFF0
 
-        # the first box is used as a tentative master
-        cur_timecounter = int(box_conns[0].get_current_timecounter())
-        latest_trigger_timecounter = max(
-            bc.last_trigger_timecounter for bc in box_conns
-        )
-        timecounter = (
-            max(latest_trigger_timecounter, cur_timecounter) + delay
-        ) & 0xFFFFFFFFFFFFFFF0
-
-        for bc in box_conns:
-            if bc.box_name in c[QSConstants.ACQ_CNXT_TAG]:
-                cap_task, awg_task = bc.start_capture_by_awg_trigger(
-                    c.ID,
-                    runits=c[QSConstants.ACQ_CNXT_TAG][bc.box_name],
-                    channels=c[QSConstants.DAC_CNXT_TAG][bc.box_name],
-                    timecounter=timecounter,
-                )
-                c[QSConstants.CAP_TASK_TAG][bc.box_name] = cap_task
-            else:
-                awg_task = bc.start_wavegen(
-                    c.ID,
-                    channels=c[QSConstants.DAC_CNXT_TAG][bc.box_name],
-                    timecounter=timecounter,
-                )
-            c[QSConstants.AWG_TASK_TAG][bc.box_name] = awg_task
-            print(bc.box_name, "kick at ", timecounter)
-        release_all_locks(box_conns, c.ID)
+            for bc in box_conns:
+                if bc.box_name in c[QSConstants.ACQ_CNXT_TAG]:
+                    cap_task, awg_task = bc.start_capture_by_awg_trigger(
+                        c.ID,
+                        runits=c[QSConstants.ACQ_CNXT_TAG][bc.box_name],
+                        channels=c[QSConstants.DAC_CNXT_TAG][bc.box_name],
+                        timecounter=timecounter,
+                    )
+                    c[QSConstants.CAP_TASK_TAG][bc.box_name] = cap_task
+                else:
+                    awg_task = bc.start_wavegen(
+                        c.ID,
+                        channels=c[QSConstants.DAC_CNXT_TAG][bc.box_name],
+                        timecounter=timecounter,
+                    )
+                c[QSConstants.AWG_TASK_TAG][bc.box_name] = awg_task
+                print(bc.box_name, "kick at ", timecounter)
         return True
 
     @setting(107, "DAQ Stop", returns=["b"])
@@ -1111,6 +1109,40 @@ class QuBE_Server(DeviceServer):
         elif enabled is False:
             dev.set_rfswitch(RfSwitchState.open)
         return dev.get_rfswitch()
+
+    @setting(600, "List Boxes", returns=["*s"])
+    def list_boxes(self, c):
+        return list(self._name_to_box_conn.keys())
+
+    @setting(601, "Reconnect Box", box_name=["s"], linkup=["b"], returns=["b"])
+    def reconnect_box(self, c, box_name, linkup=False):
+        if box_name not in self._name_to_box_conn:
+            raise ValueError(f"Box with name {box_name} not found.")
+        box_conn = self._name_to_box_conn[box_name]
+
+        try:
+            _dev_selected: Optional[DeviceWrapper] = self.selectedDevice(c)
+        except DeviceNotSelectedError:
+            _dev_selected = None
+        locked_devices = []
+        try:
+            for dev in self.devices.values():
+                if dev.box_conn.box_name == box_name:
+                    self.selectDevice(c, dev.name)
+                    self.lock_device(c, timeout=None)
+                    locked_devices.append(dev)
+
+            with locked_boxes([box_conn], c.ID):
+                box_conn.disconnect(c.ID)
+                box_conn.connect(linkup)
+        except DeviceLockedError as e:
+            print(sys._getframe().f_code.co_name, e)  # TODO: improve the message
+        finally:
+            for dev in locked_devices:
+                self.selectDevice(c, dev.name)
+                self.release_device(c)
+            if _dev_selected is not None:
+                self.selectDevice(c, _dev_selected.name)
 
 
 def _convert_to_builtin_type(np_array, ensure_list=False):

--- a/tests/test_server_with_device.py
+++ b/tests/test_server_with_device.py
@@ -1,5 +1,6 @@
 import os
 import random
+from collections.abc import Iterator
 from unittest.mock import MagicMock
 
 import matplotlib.pyplot as plt
@@ -7,6 +8,7 @@ import numpy as np
 import pytest
 from dotenv import load_dotenv
 from labrad import types as T
+from labrad.devices import DeviceLockedError
 from labrad.units import ns
 from labrad.util import ContextDict
 from quel_ic_config import force_unlock_all_boxes
@@ -59,25 +61,30 @@ def context() -> ContextDict:
     return context
 
 
-def _find_readout_portname(qube_server) -> str:
+@pytest.fixture
+def another_context() -> ContextDict:
+    context = ContextDict()
+    context.ID = 8888  # type: ignore
+    return context
+
+
+def _find_readout_portname(qube_server) -> Iterator[str]:
     _, names = qube_server.deviceLists()
     for name in names:
         if "readin" in name and "readout" in name:
-            return name
-    raise RuntimeError(f"Paired port not found from {qube_server.name}.")
+            yield name
 
 
-def _find_control_portname(qube_server) -> str:
+def _find_control_portname(qube_server) -> Iterator[str]:
     _, names = qube_server.deviceLists()
     for name in names:
         if "control" in name:
-            return name
-    raise RuntimeError(f"Control port not found from {qube_server.name}.")
+            yield name
 
 
 @test_with_devices
 def test_readin_readout_with_decimation(qube_server: QuBE_Server, context):
-    readout_portname = _find_readout_portname(qube_server)
+    readout_portname = next(_find_readout_portname(qube_server))
 
     sequence_length = 10.24  # in us. length must be a multiple of 10240ns.
     n_sample = int(sequence_length * QSConstants.DACBB_SAMPLE_R + 0.5)
@@ -137,6 +144,33 @@ def test_readin_readout_with_decimation(qube_server: QuBE_Server, context):
 
     correlation = np.sum(multipled)
     assert np.abs(correlation) > 0.94
+
+
+@test_with_devices
+def test_lock_device(qube_server: QuBE_Server, context, another_context):
+    portname_iter = _find_control_portname(qube_server)
+    port1 = next(portname_iter)
+    port2 = next(portname_iter)
+
+    qube_server.select_device(context, port1)  # type: ignore
+    qube_server.lock_device(context, timeout=None)
+
+    # without error
+    qube_server.select_device(context, port1)  # type: ignore
+
+    # raises DeviceLockedError when accessed with another context
+    with pytest.raises(DeviceLockedError):
+        qube_server.select_device(another_context, port1)  # type: ignore
+
+    # selecting to another device with another context does not raise the error.
+    qube_server.select_device(another_context, port2)  # type: ignore
+
+    # release lock for the device
+    qube_server.select_device(context, port1)  # type: ignore
+    qube_server.release_device(context)
+
+    # port1 is selectable from another context now
+    qube_server.select_device(another_context, port1)  # type: ignore
 
 
 @test_with_devices

--- a/tests/test_server_with_device.py
+++ b/tests/test_server_with_device.py
@@ -1,0 +1,151 @@
+import os
+import random
+from unittest.mock import MagicMock
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from dotenv import load_dotenv
+from labrad import types as T
+from labrad.units import ns
+from labrad.util import ContextDict
+from quel_ic_config import force_unlock_all_boxes
+
+from qube_server.constants import QSConstants
+from qube_server.model import PossibleLinks, Skews
+from qube_server.server import QuBE_Server
+
+load_dotenv()
+
+_DO_PLOT: bool = os.getenv("QS_TEST_PLOT") == "True" or False
+_ARTIFACT_DIR: str = "artifacts/"
+
+_VARNAME_SKIP_TESTS_WITH_DEVICES = "QS_SKIP_TESTS_WITH_DEVICES"
+_SKIP_TESTS_WITH_DEVICES: bool = (
+    os.getenv(_VARNAME_SKIP_TESTS_WITH_DEVICES) == "True" or True
+)
+test_with_devices = pytest.mark.skipif(
+    _SKIP_TESTS_WITH_DEVICES,
+    reason=f"since the environment variable '{_VARNAME_SKIP_TESTS_WITH_DEVICES}' is True or is not set.",
+)
+
+
+@pytest.fixture(scope="function")
+def qube_server_base():
+    server = QuBE_Server()
+    server.log = MagicMock()
+    with open(os.environ["QS_TEST_LINKS_JSON_PATH"]) as fp:
+        links = PossibleLinks.model_validate_json(fp.read())
+    with open(os.environ["QS_TEST_SKEW_JSON_PATH"]) as fp:
+        skew = Skews.model_validate_json(fp.read())
+    server._get_possible_links = lambda: links  # type: ignore
+    server._get_skew_config = lambda: skew  # type: ignore
+    server.initServer()
+    yield server
+    del server
+    force_unlock_all_boxes()
+
+
+@pytest.fixture
+def qube_server(qube_server_base, context):
+    qube_server_base.initContext(context)
+    yield qube_server_base
+
+
+@pytest.fixture
+def context() -> ContextDict:
+    context = ContextDict()
+    context.ID = 9999  # type: ignore
+    return context
+
+
+def _find_readout_portname(qube_server) -> str:
+    _, names = qube_server.deviceLists()
+    for name in names:
+        if "readin" in name and "readout" in name:
+            return name
+    raise RuntimeError(f"Paired port not found from {qube_server.name}.")
+
+
+def _find_control_portname(qube_server) -> str:
+    _, names = qube_server.deviceLists()
+    for name in names:
+        if "control" in name:
+            return name
+    raise RuntimeError(f"Control port not found from {qube_server.name}.")
+
+
+@test_with_devices
+def test_readin_readout_with_decimation(qube_server: QuBE_Server, context):
+    readout_portname = _find_readout_portname(qube_server)
+
+    sequence_length = 10.24  # in us. length must be a multiple of 10240ns.
+    n_sample = int(sequence_length * QSConstants.DACBB_SAMPLE_R + 0.5)
+
+    qube_server.select_device(context, key=readout_portname)  # type: ignore
+    qube_server.number_of_shots(context, 1)
+    qube_server.sequence_length(context, T.Value(sequence_length, "us"))
+    qube_server.repetition_time(context, T.Value(2 * sequence_length, "us"))
+
+    freq_mhz = random.uniform(-100, 100)
+    amp = 0.999
+    wavedata = amp * np.exp(
+        2j * np.pi * freq_mhz * np.arange(n_sample) / QSConstants.DACBB_SAMPLE_R
+    )
+    channel = 0
+    qube_server.upload_waveform(context, [wavedata], channel)
+    qube_server.upload_parameters(context, [channel])
+    qube_server.internal_loopback(context, True)
+
+    qube_server.frequency_local(context, T.Value(8500, "MHz"))  # 8.5+1.5=10.0GHz
+    qube_server.frequency_tx_nco(context, T.Value(1500.0, "MHz"))  # 1.5GHz.
+    qube_server.coarse_rx_nco_frequency(
+        context, T.Value(1500, "MHz")
+    )  # better to be the same as tx_nco
+    qube_server.frequency_tx_fine_nco(
+        context, channel, T.Value(0, "MHz")
+    )  # better not to use it.
+
+    mux_channel = 0
+    readout_window = [
+        (
+            8 * 128 * ns,
+            (8 + 16) * 128 * ns,
+        )
+    ]
+    qube_server.acquisition_window(context, mux_channel, readout_window)
+    qube_server.acquisition_mode(context, mux_channel, "2")
+
+    qube_server.upload_readout_parameters(context, [mux_channel])
+
+    qube_server.daq_start(context)
+    qube_server.daq_trigger(context)
+    qube_server.daq_stop(context)
+
+    downloaded_waveform = qube_server.download_waveform(context, [mux_channel])
+    observed = downloaded_waveform[0] / np.linalg.norm(
+        downloaded_waveform[0]
+    )  # normalize
+    wavedata_trimmed = wavedata[::4][: len(observed)]  # decimated by 4 in mode-2
+    wavedata_normalized = wavedata_trimmed / np.linalg.norm(wavedata_trimmed)
+    multipled = np.conjugate(observed) * wavedata_normalized
+
+    if _DO_PLOT:
+        plt.plot(multipled.real)
+        plt.plot(multipled.imag)
+        plt.savefig(_ARTIFACT_DIR + "test_readin_readout.png")
+
+    correlation = np.sum(multipled)
+    assert np.abs(correlation) > 0.94
+
+
+@test_with_devices
+def test_reconnect_box(qube_server: QuBE_Server, context):
+    box_names = qube_server.list_boxes(context)
+    qube_server.reconnect_box(context, box_names[0])
+
+
+@test_with_devices
+def test_relinkup_box(qube_server: QuBE_Server, context):
+    box_names = qube_server.list_boxes(context)
+    qube_server.reconnect_box(context, box_names[0], linkup=True)

--- a/tests/test_server_without_device.py
+++ b/tests/test_server_without_device.py
@@ -57,7 +57,8 @@ def _get_dummy_registry():
 def qube_server():
     server = QuBE_Server()
     server.log = MagicMock()
-    server._get_registry_service = _get_dummy_registry  # type: ignore
+    server._get_possible_links = lambda: {}  # type: ignore
+    server._get_skew_config = lambda: {}  # type: ignore
     DeviceServer.initServer(server)
     return server
 

--- a/uv.lock
+++ b/uv.lock
@@ -1362,6 +1362,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pycairo"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/d9/412da520de9052b7e80bfc810ec10f5cb3dbfa4aa3e23c2820dc61cdb3d0/pycairo-1.28.0.tar.gz", hash = "sha256:26ec5c6126781eb167089a123919f87baa2740da2cca9098be8b3a6b91cc5fbc", size = 662477, upload-time = "2025-04-14T20:11:08.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/67/6e5d6328c6037f0479017f51e97f5cbb79a68ed6e93f671dac17cb47bf2e/pycairo-1.28.0-cp310-cp310-win32.whl", hash = "sha256:53e6dbc98456f789965dad49ef89ce2c62f9a10fc96c8d084e14da0ffb73d8a6", size = 750438, upload-time = "2025-04-14T20:10:43.722Z" },
+    { url = "https://files.pythonhosted.org/packages/00/79/e941186c2275333643504f57711b157ba17e81a2be805346585ad7fd382e/pycairo-1.28.0-cp310-cp310-win_amd64.whl", hash = "sha256:c8ab91a75025f984bc327ada335c787efb61c929ea0512063793cb36cee503d4", size = 841526, upload-time = "2025-04-14T20:10:45.557Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4b/3495baabd3c830bf80bf112a0e645342bfe8f3fc05ed6423444adf62d496/pycairo-1.28.0-cp310-cp310-win_arm64.whl", hash = "sha256:e955328c1a5147bf71ee94e206413ce15e12630296a79788fcd246c80e5337b8", size = 691866, upload-time = "2025-04-16T19:30:17.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/94/47d75f4eaac865f32e0550ed42869f8b3c4036f8e2b1e6163e9548f4d44f/pycairo-1.28.0-cp311-cp311-win32.whl", hash = "sha256:0fee15f5d72b13ba5fd065860312493dc1bca6ff2dce200ee9d704e11c94e60a", size = 750441, upload-time = "2025-04-14T20:10:48.311Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/02/1169a2917b043998585f9dd0f36da618947fdf9b6cc0e9ff9852aa4d548b/pycairo-1.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:6339979bfec8b58a06476094a9a5c104bd5a99932ddaff16ca0d9203d2f4482c", size = 841536, upload-time = "2025-04-14T20:10:51.112Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/13031086fb4d4ea71568d9ce74e03afbb2e18047f1e6b4e8674851f0414f/pycairo-1.28.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6ae15392e28ebfc0b35d8dc05d395d3b6be4bad9ad4caecf0fa12c8e7150225", size = 691895, upload-time = "2025-04-16T19:30:20.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d7/206d7945aac5c6c889e7fea4011410d1311455a1d8dfce66106d8d700b7f/pycairo-1.28.0-cp312-cp312-win32.whl", hash = "sha256:c00cfbb7f30eb7ca1d48886712932e2d91e8835a8496f4e423878296ceba573e", size = 750594, upload-time = "2025-04-14T20:10:53.72Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/ba/259fc9a4d3afdad1e5b9db52b9d8a5df67f70dd787167185e8ec8a1af007/pycairo-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:d50d190f5033992b55050b9f337ee42a45c3568445d5e5d7987bab96c278d8a6", size = 841767, upload-time = "2025-04-14T20:10:56.711Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/08/aa0903612ea0e8686ad6af58d4fb9cbab8ee0b0831201cddf7abd578d045/pycairo-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:957e0340ee1c279d197d4f7cfa96f6d8b48e453eec711fca999748d752468ff4", size = 691687, upload-time = "2025-04-16T19:30:23.729Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a7/c3e5ed55781dfe1b31eb4a2482aeae707671f3d36b0ea53a1722f4a3dfe9/pycairo-1.28.0-cp313-cp313-win32.whl", hash = "sha256:d13352429d8a08a1cb3607767d23d2fb32e4c4f9faa642155383980ec1478c24", size = 750594, upload-time = "2025-04-14T20:10:59.284Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/1c/ebadd290748aff3b6bc35431114d41e7a42f40a4b988c2aaf2dfed5d8156/pycairo-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:082aef6b3a9dcc328fa648d38ed6b0a31c863e903ead57dd184b2e5f86790140", size = 841774, upload-time = "2025-04-14T20:11:01.79Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ce/a3f5f1946613cd8a4654322b878c59f273c6e9b01dfadadd3f609070e0b9/pycairo-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:026afd53b75291917a7412d9fe46dcfbaa0c028febd46ff1132d44a53ac2c8b6", size = 691675, upload-time = "2025-04-16T19:30:26.565Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1b/1f5da2b2e44b33a5b269ff28af710b0a7903001d9cf8a40d00fc944a5092/pycairo-1.28.0-cp314-cp314-win32.whl", hash = "sha256:d0ab30585f536101ad6f09052fc3895e2a437ba57531ea07223d0e076248025d", size = 766699, upload-time = "2025-07-24T06:36:07.267Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/91/1d5f18bd3ed469b1de8f83bfbf8bd67d23439f075151b66740fd35356190/pycairo-1.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:94f2ed204999ab95a0671a0fa948ffbb9f3d6fb8731fe787917f6d022d9c1c0f", size = 868725, upload-time = "2025-07-24T06:36:09.597Z" },
+    { url = "https://files.pythonhosted.org/packages/79/0e/476ffe64b309672aa4012897d91a2bda7e5b2eb43504bbff48be03e5055c/pycairo-1.28.0-cp39-cp39-win32.whl", hash = "sha256:3ed16d48b8a79cc584cb1cb0ad62dfb265f2dda6d6a19ef5aab181693e19c83c", size = 750680, upload-time = "2025-04-14T20:11:04.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/77/872e843993bb152f93e970f0807ee08b5a496116ad8eadfa0a1590452111/pycairo-1.28.0-cp39-cp39-win_amd64.whl", hash = "sha256:da0d1e6d4842eed4d52779222c6e43d254244a486ca9fdab14e30042fd5bdf28", size = 842157, upload-time = "2025-04-14T20:11:05.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/c5/fce33dbb973c5ee7606167056502a70eb316350c41c7656e5739a5f9e490/pycairo-1.28.0-cp39-cp39-win_arm64.whl", hash = "sha256:458877513eb2125513122e8aa9c938630e94bb0574f94f4fb5ab55eb23d6e9ac", size = 691902, upload-time = "2025-04-16T19:30:28.615Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1587,6 +1612,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+]
+
+[[package]]
 name = "python-ulid"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1666,6 +1700,8 @@ dependencies = [
     { name = "e7awghal" },
     { name = "pydantic" },
     { name = "pylabrad" },
+    { name = "pytest-twisted" },
+    { name = "python-dotenv" },
     { name = "quel-ic-config" },
 ]
 
@@ -1683,6 +1719,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.4.2" },
     { name = "pylabrad", specifier = ">=0.98.2" },
     { name = "quel-ic-config", specifier = ">=0.10.4" },
+    { name = "pytest-twisted", specifier = ">=1.14.3" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
- Added tests using devices.
  - By default, they are skipped.
- Information that is dependent on the environment for testing is read from the `.env` file. This file is not included in version control and is assumed to be stored locally by the user or developer.
  - The `.env.example` file provides examples of the required content for this file.
- Added an API to control the internal loopback switch for read-in and -out.
- Added an API to reconnect/relinkup a box. It may be useful when troubleshooting like power-cycling.
- Some refactoring